### PR TITLE
Fix universe files processing, `share` datatype, refactoring codes

### DIFF
--- a/DataProcessing/Program.cs
+++ b/DataProcessing/Program.cs
@@ -16,7 +16,6 @@
 using System;
 using System.IO;
 using QuantConnect.Configuration;
-using QuantConnect.DataSource;
 using QuantConnect.Logging;
 using QuantConnect.Util;
 

--- a/QuiverInsiderTrading.cs
+++ b/QuiverInsiderTrading.cs
@@ -14,19 +14,16 @@
  *
 */
 
-using System;
+using Microsoft.VisualBasic.FileIO;
+using Newtonsoft.Json;
 using NodaTime;
 using ProtoBuf;
-using System.IO;
 using QuantConnect.Data;
-using System.Collections.Generic;
-using Microsoft.VisualBasic.FileIO;
-using System.Globalization;
 using QuantConnect.Util;
-using Newtonsoft.Json;
-using static QuantConnect.StringExtensions;
-
-
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 
 namespace QuantConnect.DataSource
 {
@@ -57,7 +54,7 @@ namespace QuantConnect.DataSource
         /// </summary>
         [ProtoMember(13)]
         [JsonProperty(PropertyName = "Shares")]
-        public string Shares { get; set; }
+        public decimal? Shares { get; set; }
 
         /// <summary>
         /// PricePerShare
@@ -104,9 +101,9 @@ namespace QuantConnect.DataSource
 
             var parsedDate = Parse.DateTimeExact(csv[0], "yyyyMMdd");//, "'yyyy-MM-dd\'T\'HH:mm:ss.SSS\'Z\''"      
             Name = csv[1];
-            Shares = csv[2];
-            PricePerShare = csv[3].IfNotNullOrEmpty<decimal?>(s => Parse.Decimal(s));
-            SharesOwnedFollowing = csv[4].IfNotNullOrEmpty<decimal?>(s => Parse.Decimal(s));
+            Shares = csv[2].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture));
+            PricePerShare = csv[3].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture));
+            SharesOwnedFollowing = csv[4].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture));
 
             Time = parsedDate;
             _period = TimeSpan.FromDays(1);

--- a/QuiverInsiderTradingAlgorithm.cs
+++ b/QuiverInsiderTradingAlgorithm.cs
@@ -51,8 +51,8 @@ namespace QuantConnect.DataLibrary.Tests
             if (!data.IsNullOrEmpty())
             {
                 // based on the custom data property we will buy or short the underlying equity
-                var t = float.Parse(data[_customDataSymbol].Shares, System.Globalization.CultureInfo.InvariantCulture);
-                if (t > 0.0)
+                var t = data[_customDataSymbol].Shares;
+                if (t > 0m)
                 {
                     SetHoldings(_equitySymbol, 1);
                 }

--- a/QuiverInsiderTradingUniverse.cs
+++ b/QuiverInsiderTradingUniverse.cs
@@ -21,7 +21,6 @@ using System.IO;
 using ProtoBuf;
 using NodaTime;
 using QuantConnect.Data;
-using QuantConnect.Orders;
 using static QuantConnect.StringExtensions;
 
 namespace QuantConnect.DataSource
@@ -45,7 +44,7 @@ namespace QuantConnect.DataSource
         /// <summary>
         /// Shares
         /// </summary>
-        public string Shares { get; set; }
+        public decimal? Shares { get; set; }
 
         /// <summary>
         /// PricePerShare
@@ -101,13 +100,15 @@ namespace QuantConnect.DataSource
         public override BaseData Reader(SubscriptionDataConfig config, string line, DateTime date, bool isLiveMode)
         {
             var csv = line.Split(',');
+            var share = csv[4].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture));
             var price = csv[5].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture));
             var sharesAfter = csv[6].IfNotNullOrEmpty<decimal?>(s => decimal.Parse(s, NumberStyles.Any, CultureInfo.InvariantCulture));
+            
             return new QuiverInsiderTradingUniverse
             {
                 Time = Parse.DateTimeExact(csv[2], "yyyyMMdd") - Period,
                 Name = csv[3],
-                Shares = csv[4],
+                Shares = share,
                 PricePerShare = price,
                 SharesOwnedFollowing = sharesAfter,
 

--- a/QuiverInsiderTradingUniverseAlgorithm.cs
+++ b/QuiverInsiderTradingUniverseAlgorithm.cs
@@ -14,12 +14,9 @@
  *
 */
 
-using System;
 using System.Linq;
-using QuantConnect.Data;
 using QuantConnect.Data.UniverseSelection;
 using QuantConnect.DataSource;
-
 
 namespace QuantConnect.Algorithm.CSharp
 {
@@ -45,7 +42,7 @@ namespace QuantConnect.Algorithm.CSharp
             {
                 foreach (var datum in data)
                 {
-                    Log($"{datum.Symbol},{datum.Name},{datum.Shares},{datum.PricePerShare}");
+                    Log($"{datum.Symbol},{datum.Name},{datum.Shares},{datum.PricePerShare},{datum.SharesOwnedFollowing}");
                 }
 
                 // define our selection criteria

--- a/tests/QuiverInsiderTradingTests.cs
+++ b/tests/QuiverInsiderTradingTests.cs
@@ -93,7 +93,7 @@ namespace QuantConnect.DataLibrary.Tests
                 Time = DateTime.Today,
                 DataType = MarketDataType.Base,
                 Name = "Institution name",
-                Shares = "Number of Shares",
+                Shares = 0.0m,
                 PricePerShare = 0.0m,
                 SharesOwnedFollowing = 0.0m,
             };


### PR DESCRIPTION
Hi Jas!!

I've made some changes on the universe file since the original way would have duplicated rows for the same equity which would result in errors in LEAN, like
```
20100101.csv
aapl 2T,aapl,joe,10,20,10
aapl 2T,aapl,betty,20,20.05,30
```
now it should be changed into
```
20100101.csv
aapl 2T,aapl,joe;betty,30,20.033333,40
```

I'm able to fetch the data files (per stock base ones) and they look good! but soon the HTTP request is too flooded and blocks me from continuing, so I cannot test if these changes on the universe file are valid. So maybe you'll have to change the `_indexGate = new RateGate(10, TimeSpan.FromSeconds(1.1));` in the constructor of [QuiverInsiderTradingDataDownloader.cs](https://github.com/JaskaranBakshi/Lean.DataSource.QuiverInsiderTrading/blob/4538c41cecd97c6b79e5f5cca4e461a7ddad9f17/DataProcessing/QuiverInsiderTradingDataDownloader.cs#L84) file to limit the rate more.

btw my IP if it helps: `124.244.137.73`